### PR TITLE
Register sh file extension

### DIFF
--- a/lib/coderay_bash.rb
+++ b/lib/coderay_bash.rb
@@ -4,3 +4,6 @@ path = File.join File.expand_path(File.dirname(__FILE__))
 
 require File.join(path, "coderay/scanners/bash.rb")
 require File.join(path, "coderay/scanners/erb_bash.rb")
+
+# Register file types
+::CodeRay::FileType::TypeFromExt['sh'] = :bash


### PR DESCRIPTION
It was useful for me in Redmine. When I browse the repository, Redmine calls coderay with the file name (coderay than extracts the extension in the FileType map).
